### PR TITLE
Fix typings for Flow 0.54.0+

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -387,7 +387,7 @@ export function enumeration(...values: Array<mixed>) {
   return node;
 }
 
-export class OneOfNode<A> extends Node<A> {
+export class OneOfNode<V> extends Node<V> {
 
   nodes: Array<Node<*>>;
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -387,7 +387,7 @@ export function enumeration(...values: Array<mixed>) {
   return node;
 }
 
-export class OneOfNode extends Node {
+export class OneOfNode<A> extends Node<A> {
 
   nodes: Array<Node<*>>;
 


### PR DESCRIPTION
As of Flow 0.54.0, Flow has required that type parameters be annotated in class declarations, instead of left in "point-free" form.

*From the [Flow changelog](https://github.com/facebook/flow/blob/master/Changelog.md):*
```
Extending a polymorphic class must now explicitly specify the parent class's type args. 
That is, class A<T> {}; class B extends A {} is now an error,
but class C extends A<string> {} or class D<T> extends A<T> {} is ok.
```

---

This PR fixes the following error message, tested on flow 0.55.0:

```
Error: src/schema.js:390
390: export class OneOfNode extends Node {
                                    ^^^^ polymorphic type: class type: Node. Too few type arguments. Expected at least 1
128: export class Node<V> {
                       ^ See type parameters of definition here


Found 1 error
```