### PR TITLE
Add return type to improve type coverage

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -17,6 +17,7 @@
 
 [libs]
 flow-typed
+decls
 
 [options]
 esproposal.class_static_fields=enable

--- a/decls/custom-error-instance.js
+++ b/decls/custom-error-instance.js
@@ -1,0 +1,29 @@
+// @flow
+
+declare module 'custom-error-instance' {
+  declare class CustomError extends Error {
+    constructor(messageOrProps?: string | Object, properties?: Object): this;
+
+    // These properties redeclared here are specifically for working with
+    // validated. They allow the functions to be rewritten under Flow's eyes.
+    // For more information see: https://github.com/facebook/flow/issues/1517
+    toString: () => string;
+    withContext: () => Error;
+    message: string;
+    originalMessage: string;
+  }
+
+  // declare type CustomErrorFactory = (
+  //   message?: string,
+  //   config?: Object,
+  // ) => CustomError
+
+  declare type CustomErrorApi = (
+    name?: string,
+    parent?: CustomError,
+    properties?: Object,
+    factory?: Function,
+  ) => Class<CustomError>;
+
+  declare export default CustomErrorApi;
+}

--- a/decls/custom-error-instance.js
+++ b/decls/custom-error-instance.js
@@ -1,5 +1,9 @@
 // @flow
 
+// This is a partial libdef for custom-error-instance. It's filled out enough
+// such that it should work for the purposes of validated. However, the
+// documentation shows a potentially very complex API that might be hard to Flow
+// to express to a general purpose audience such as `flow-typed`.
 declare module 'custom-error-instance' {
   declare class CustomError extends Error {
     constructor(messageOrProps?: string | Object, properties?: Object): this;
@@ -12,11 +16,6 @@ declare module 'custom-error-instance' {
     message: string;
     originalMessage: string;
   }
-
-  // declare type CustomErrorFactory = (
-  //   message?: string,
-  //   config?: Object,
-  // ) => CustomError
 
   declare type CustomErrorApi = (
     name?: string,

--- a/src/schema.js
+++ b/src/schema.js
@@ -28,7 +28,8 @@ export type ValidateResult<V> = {
   +value: V,
 };
 
-type Refine<A, B> = (value: A, error: (message: GenericMessage) => void) => B;
+// Maybe this should be Error instead of mixed?
+type Refine<A, B> = (value: A, error: (message: GenericMessage) => mixed) => B;
 
 export class Context {
   parent: ?Context;

--- a/src/schema.js
+++ b/src/schema.js
@@ -66,7 +66,7 @@ export class Context {
     return originalMessage;
   }
 
-  error(inMessage: ?GenericMessage) {
+  error(inMessage: ?GenericMessage): ValidationError {
     let context = this;
     let contextMessages = [];
     do {


### PR DESCRIPTION
The project I work on has a requirement for 100% type coverage. When making my own custom validators, I noticed properties hanging off `context` weren't something Flow could infer (they become `any`). Adding this return type is enough for Flow to achieve type coverage with usage of `context`.