### PR TITLE
add Node.type field

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -127,6 +127,8 @@ export function validationError(
 }
 
 export class Node<V> {
+  type: V;
+
   validate(_context: Context): ValidateResult<V> {
     let message = `${this.constructor.name}.validate(context) is not implemented`;
     throw new Error(message);


### PR DESCRIPTION
This adds a `Node.type` field to be used as with Flow's `typeof` operator. For example:

```javascript
const PersonFields = partialObject({ name: string, age: number, email: string });
type Person = typeof PersonFields.type;
const user: Person = validate(PersonFields, input);
```