### PR TITLE
Move babel config out of package.json

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    "prometheusresearch"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,11 +8,6 @@
   "scripts": {
     "test": "make build lint check test"
   },
-  "babel": {
-    "presets": [
-      "prometheusresearch"
-    ]
-  },
   "eslintConfig": {
     "extends": "prometheusresearch",
     "globals": {


### PR DESCRIPTION
This should fix #26.

In React Native Jest fails with an error about cannot find babel preset `prometheusresearch`.

I believe the reason is that in package.json we have some babel config which gets checked into npm.

For some reason this confuses Jest/babel and it tries to convert the published code using babel.

This PR moves this config to a `.babelrc` file in the project root. This file will not get published with npm.