### PR TITLE
Fix type error with flow > 0.70

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-config-prometheusresearch": "^0.4.0",
     "eslint-plugin-flowtype": "^2.32.1",
     "eslint-plugin-react": "^6.10.3",
-    "flow-bin": "^0.66.0",
+    "flow-bin": "^0.70.0",
     "mocha": "^3.3.0",
     "mocha-doctest": "^0.3.4",
     "prettier": "^1.7.0"

--- a/src/schema.js
+++ b/src/schema.js
@@ -213,7 +213,7 @@ export class MappingNode<V> extends Node<MappingOf<V>> {
   }
 }
 
-export function mapping<V>(valueNode?: Node<V> = any): MappingNode<V> {
+export function mapping<V>(valueNode?: Node<V> = new AnyNode()): MappingNode<V> {
   return new MappingNode(valueNode);
 }
 
@@ -317,7 +317,7 @@ export function partialObject<S: {[name: string]: Node<*>}>(
 export class SequenceNode<V> extends Node<Array<V>> {
   valueNode: Node<V>;
 
-  constructor(valueNode: Node<V> = any) {
+  constructor(valueNode: Node<V> = new AnyNode()) {
     super();
     this.valueNode = valueNode;
   }
@@ -327,12 +327,12 @@ export class SequenceNode<V> extends Node<Array<V>> {
   }
 }
 
-export function arrayOf<V>(valueNode: Node<V> = any): SequenceNode<V> {
+export function arrayOf<V>(valueNode: Node<V> = new AnyNode()): SequenceNode<V> {
   return new SequenceNode(valueNode);
 }
 
 // Kept for backwards compatibility. Use `arrayOf` instead.
-export function sequence<V>(valueNode: Node<V> = any): SequenceNode<V> {
+export function sequence<V>(valueNode: Node<V> = new AnyNode()): SequenceNode<V> {
   return new SequenceNode(valueNode);
 }
 


### PR DESCRIPTION
This addresses issue #29

It looks like there was a problem with the `AnyNode` variable. It's declared as the existential type and is used in the different node builder functions as the default value. But even if the type isn't declared it can only have one type so it can't work for all the node builder functions. I replaced the usage of the same variable with a new `AnyNode` and that seemed to resolve the issue